### PR TITLE
Better graph layouts

### DIFF
--- a/dist/joint.js
+++ b/dist/joint.js
@@ -26225,8 +26225,17 @@ joint.layout.DirectedGraph = {
 
     exportElement: function(element) {
 
-        // The width and height of the element.
-        return element.size();
+        var nodeSize = element.size();
+        var node = {
+            // The width of the element.
+            width: nodeSize.width,
+            // The height of the element.
+            height: nodeSize.height,
+            // The port names of the element.
+            ports: _.map(element.getPorts(), "id")
+        };
+
+        return node;
     },
 
     exportLink: function(link) {
@@ -26234,7 +26243,7 @@ joint.layout.DirectedGraph = {
         var labelSize = link.get('labelSize') || {};
         var edge = {
             // The number of ranks to keep between the source and target of the edge.
-            minLen: link.get('minLen') || 1,
+            minlen: link.get('minLen') || 1,
             // The weight to assign edges. Higher weight edges are generally
             // made shorter and straighter than lower weight edges.
             weight: link.get('weight') || 1,
@@ -26247,7 +26256,11 @@ joint.layout.DirectedGraph = {
             // The width of the edge label in pixels.
             width: labelSize.width || 0,
             // The height of the edge label in pixels.
-            height: labelSize.height || 0
+            height: labelSize.height || 0,
+            // The source port of the edge.
+            vport: link.source().port,
+            // The target port of the edge.
+            wport: link.target().port
         };
 
         return edge;
@@ -26445,6 +26458,7 @@ joint.layout.DirectedGraph = {
         var setEdgeLabel = opt.setEdgeLabel || joint.util.noop;
         var setEdgeName = opt.setEdgeName || joint.util.noop;
         var collection = graph.get('cells');
+        collection.models = _.sortBy(collection.models, "id");
 
         for (var i = 0, n = collection.length; i < n; i++) {
 

--- a/plugins/layout/DirectedGraph/joint.layout.DirectedGraph.js
+++ b/plugins/layout/DirectedGraph/joint.layout.DirectedGraph.js
@@ -13,8 +13,17 @@ joint.layout.DirectedGraph = {
 
     exportElement: function(element) {
 
-        // The width and height of the element.
-        return element.size();
+        var nodeSize = element.size();
+        var node = {
+            // The width of the element.
+            width: nodeSize.width,
+            // The height of the element.
+            height: nodeSize.height,
+            // The port names of the element.
+            ports: _.map(element.getPorts(), "id")
+        };
+
+        return node;
     },
 
     exportLink: function(link) {
@@ -22,7 +31,7 @@ joint.layout.DirectedGraph = {
         var labelSize = link.get('labelSize') || {};
         var edge = {
             // The number of ranks to keep between the source and target of the edge.
-            minLen: link.get('minLen') || 1,
+            minlen: link.get('minLen') || 1,
             // The weight to assign edges. Higher weight edges are generally
             // made shorter and straighter than lower weight edges.
             weight: link.get('weight') || 1,
@@ -35,7 +44,11 @@ joint.layout.DirectedGraph = {
             // The width of the edge label in pixels.
             width: labelSize.width || 0,
             // The height of the edge label in pixels.
-            height: labelSize.height || 0
+            height: labelSize.height || 0,
+            // The source port of the edge.
+            vport: link.source().port,
+            // The target port of the edge.
+            wport: link.target().port
         };
 
         return edge;
@@ -233,6 +246,7 @@ joint.layout.DirectedGraph = {
         var setEdgeLabel = opt.setEdgeLabel || joint.util.noop;
         var setEdgeName = opt.setEdgeName || joint.util.noop;
         var collection = graph.get('cells');
+        collection.models = _.sortBy(collection.models, "id");
 
         for (var i = 0, n = collection.length; i < n; i++) {
 


### PR DESCRIPTION
This uses port information to get a better graph layout (less criss-crossing of edges).  Also, nodes and edges are sorted first to provide a consistent layout for the same graph.

This is dependent on https://github.com/webpro-patch/graphlib/pull/1 and https://github.com/webpro-patch/dagre/pull/1.